### PR TITLE
Set base path in index.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,11 @@ _testmain.go
 
 *.exe
 
-# vim swp files
+# vim files
 *.swp
 *.swo
+tags
+tags.*
 
 # Desktop Services Store on macOS
 .DS_Store

--- a/pkg/server/web/handlers.go
+++ b/pkg/server/web/handlers.go
@@ -1,9 +1,11 @@
 package web
 
 import (
+	"html/template"
 	"net/http"
 	"os"
 
+	"github.com/inbucket/inbucket/pkg/config"
 	"github.com/rs/zerolog/log"
 )
 
@@ -80,5 +82,23 @@ func requestLoggingWrapper(next http.Handler) http.Handler {
 		log.Debug().Str("module", "web").Str("remote", req.RemoteAddr).Str("proto", req.Proto).
 			Str("method", req.Method).Str("path", req.RequestURI).Msg("Request")
 		next.ServeHTTP(w, req)
+	})
+}
+
+// spaTemplateHandler creates a handler to serve the index.html template for our SPA.
+func spaTemplateHandler(tmpl *template.Template, basePath string,
+	webConfig config.Web) http.Handler {
+	tmplData := struct {
+		BasePath string
+	}{
+		BasePath: basePath,
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		err := tmpl.Execute(w, tmplData)
+		if err != nil {
+			log.Error().Str("module", "web").Str("remote", req.RemoteAddr).Str("proto", req.Proto).
+				Str("method", req.Method).Str("path", req.RequestURI).Err(err).
+				Msg("Error rendering SPA index template")
+		}
 	})
 }

--- a/ui/public/index-dev.html
+++ b/ui/public/index-dev.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- This index file will be served by the webpack development server. -->
+  <base href="/">
+  <meta charset="utf-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="theme-color" content="#000000">
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
+  <title>Inbucket</title>
+</head>
+<body>
+  <noscript>
+    You need to enable JavaScript to run this app.
+  </noscript>
+  <div id="root"></div>
+</body>
+</html>

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <base href="{{ .BasePath }}">
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -54,11 +54,18 @@ module.exports = (env, argv) => {
         template: 'public/index.html',
         favicon: 'public/favicon.png',
       }),
+      new HtmlWebpackPlugin({
+        filename: 'index-dev.html',
+        template: 'public/index-dev.html',
+        favicon: 'public/favicon.png',
+      }),
     ],
     devServer: {
+      historyApiFallback: {
+        index: '/index-dev.html',
+      },
+      index: 'index-dev.html',
       inline: true,
-      historyApiFallback: true,
-      stats: { colors: true },
       overlay: true,
       open: true,
       proxy: [{
@@ -66,6 +73,7 @@ module.exports = (env, argv) => {
         target: 'http://localhost:9000',
         ws: true,
       }],
+      stats: { colors: true },
       watchOptions: {
         ignored: /node_modules/,
       },


### PR DESCRIPTION
- Create a new index-dev.html for webpack live server
- Update Go+index.html to set `<base href>`
- Fixes #171 