### PR TITLE
Avoid potential click jacking

### DIFF
--- a/pkg/server/web/handlers.go
+++ b/pkg/server/web/handlers.go
@@ -94,6 +94,8 @@ func spaTemplateHandler(tmpl *template.Template, basePath string,
 		BasePath: basePath,
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// ensure we do now allow click jacking
+		w.Header().Set("X-Frame-Options", "SameOrigin")
 		err := tmpl.Execute(w, tmplData)
 		if err != nil {
 			log.Error().Str("module", "web").Str("remote", req.RemoteAddr).Str("proto", req.Proto).


### PR DESCRIPTION
Hi

I am using Inbucket in my dev stack, and got a failure during a security scan due to click-jacking.

See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options

Here is my fix for this.

Thanks for the great project

