### PR TITLE
Docker frontend build runs as amd64

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -3,6 +3,7 @@ stdenv.mkDerivation rec {
   name = "env";
   env = buildEnv { name = name; paths = buildInputs; };
   buildInputs = [
+    act
     dpkg
     elmPackages.elm
     elmPackages.elm-analyse


### PR DESCRIPTION
Our current build downloads the amd64 elm binary and runs it in an arm container.  This works on GitHub due to it being an emulated environment, but on a native arm device fails with:

```
ERROR in ./src/Main.elm
Module build failed (from ./node_modules/elm-webpack-loader/index.js):
Compiler process exited with error Error attempting to run Elm compiler "elm":
Error: spawn Unknown system error -8
```

Marking the frontend build as amd64 will cause it to execute much faster on GitHub, and resolve issues migrating from webpack to parcel (#260), which is very picky about it's arm environment.  Our Dockerfile will continue to fail on native arm devices, but they will still be able to pull our prebuilt images.