### PR TITLE
Handle IP address domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Support for IP address as domain in RCPT TO (#285)
+
 
 ## [v3.0.3] - 2022-08-07
 

--- a/etc/dev-start.sh
+++ b/etc/dev-start.sh
@@ -3,6 +3,7 @@
 # description: Developer friendly Inbucket configuration
 
 export INBUCKET_LOGLEVEL="debug"
+#export INBUCKET_MAILBOXNAMING="domain"
 export INBUCKET_SMTP_REJECTDOMAINS="bad-actors.local"
 #export INBUCKET_SMTP_DEFAULTACCEPT="false"
 export INBUCKET_SMTP_ACCEPTDOMAINS="good-actors.local"

--- a/etc/swaks-tests/run-tests.sh
+++ b/etc/swaks-tests/run-tests.sh
@@ -59,3 +59,6 @@ swaks $* --data nonmime-html-inlined.raw
 
 # Incorrect charset, malformed final boundary
 swaks $* --data mime-errors.raw
+
+# IPv4 RCPT domain
+swaks $* --to="swaks@[127.0.0.1]" --h-Subject: "IPv4 RCPT Address" --body text.txt

--- a/etc/swaks-tests/run-tests.sh
+++ b/etc/swaks-tests/run-tests.sh
@@ -60,5 +60,6 @@ swaks $* --data nonmime-html-inlined.raw
 # Incorrect charset, malformed final boundary
 swaks $* --data mime-errors.raw
 
-# IPv4 RCPT domain
+# IP RCPT domain
 swaks $* --to="swaks@[127.0.0.1]" --h-Subject: "IPv4 RCPT Address" --body text.txt
+swaks $* --to="swaks@[IPv6:2001:db8:aaaa:1::100]" --h-Subject: "IPv6 RCPT Address" --body text.txt

--- a/pkg/policy/address.go
+++ b/pkg/policy/address.go
@@ -54,7 +54,8 @@ func (a *Addressing) ExtractMailbox(address string) (string, error) {
 	return local + "@" + domain, nil
 }
 
-// NewRecipient parses an address into a Recipient.
+// NewRecipient parses an address into a Recipient. This is used for parsing RCPT TO arguments,
+// not To headers.
 func (a *Addressing) NewRecipient(address string) (*Recipient, error) {
 	local, domain, err := ParseEmailAddress(address)
 	if err != nil {

--- a/pkg/policy/address.go
+++ b/pkg/policy/address.go
@@ -51,40 +51,6 @@ func (a *Addressing) ExtractMailbox(address string) (string, error) {
 	return local + "@" + domain, nil
 }
 
-// Extracts the mailbox name when domain addressing is enabled.
-func extractDomainMailbox(address string) (string, error) {
-	var local, domain string
-	var err error
-
-	if address != "" && address[0] == '[' && address[len(address)-1] == ']' {
-		// Likely an IP address in brackets, treat as domain only.
-		domain = address
-	} else {
-		local, domain, err = parseEmailAddress(address)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	if local != "" {
-		local, err = parseMailboxName(local)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	// If no domain is specified, assume this is being used for mailbox lookup via the API.
-	if domain == "" {
-		domain = local
-	}
-
-	if ValidateDomainPart(domain) == false {
-		return "", fmt.Errorf("Domain part %q in %q failed validation", domain, address)
-	}
-
-	return domain, nil
-}
-
 // NewRecipient parses an address into a Recipient. This is used for parsing RCPT TO arguments,
 // not To headers.
 func (a *Addressing) NewRecipient(address string) (*Recipient, error) {
@@ -205,6 +171,40 @@ func ValidateDomainPart(domain string) bool {
 		prev = c
 	}
 	return true
+}
+
+// Extracts the mailbox name when domain addressing is enabled.
+func extractDomainMailbox(address string) (string, error) {
+	var local, domain string
+	var err error
+
+	if address != "" && address[0] == '[' && address[len(address)-1] == ']' {
+		// Likely an IP address in brackets, treat as domain only.
+		domain = address
+	} else {
+		local, domain, err = parseEmailAddress(address)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if local != "" {
+		local, err = parseMailboxName(local)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// If no @domain is specified, assume this is being used for mailbox lookup via the API.
+	if domain == "" {
+		domain = local
+	}
+
+	if ValidateDomainPart(domain) == false {
+		return "", fmt.Errorf("Domain part %q in %q failed validation", domain, address)
+	}
+
+	return domain, nil
 }
 
 // parseEmailAddress unescapes an email address, and splits the local part from the domain part.  An

--- a/pkg/policy/address_test.go
+++ b/pkg/policy/address_test.go
@@ -326,6 +326,7 @@ func TestExtractDomainMailboxValid(t *testing.T) {
 			domain: "[IPv6:2001:db8:aaaa:1::100]",
 		},
 	}
+
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			if result, err := domainPolicy.ExtractMailbox(tc.input); tc.domain != "" && err != nil {
@@ -343,6 +344,7 @@ func TestExtractMailboxInvalid(t *testing.T) {
 	localPolicy := policy.Addressing{Config: &config.Root{MailboxNaming: config.LocalNaming}}
 	fullPolicy := policy.Addressing{Config: &config.Root{MailboxNaming: config.FullNaming}}
 	domainPolicy := policy.Addressing{Config: &config.Root{MailboxNaming: config.DomainNaming}}
+
 	// Test local mailbox naming policy.
 	localInvalidTable := []struct {
 		input, msg string
@@ -357,6 +359,7 @@ func TestExtractMailboxInvalid(t *testing.T) {
 			t.Errorf("Didn't get an error while parsing in local mode %q: %v", tt.input, tt.msg)
 		}
 	}
+
 	// Test full mailbox naming policy.
 	fullInvalidTable := []struct {
 		input, msg string
@@ -372,6 +375,7 @@ func TestExtractMailboxInvalid(t *testing.T) {
 			t.Errorf("Didn't get an error while parsing in full mode %q: %v", tt.input, tt.msg)
 		}
 	}
+
 	// Test domain mailbox naming policy.
 	domainInvalidTable := []struct {
 		input, msg string
@@ -495,6 +499,8 @@ func TestValidateLocal(t *testing.T) {
 // TestRecipientAddress verifies the Recipient.Address values returned by Addressing.NewRecipient.
 // This function parses a RCPT TO path, not a To header. See rfc5321#section-4.1.2
 func TestRecipientAddress(t *testing.T) {
+	localPolicy := policy.Addressing{Config: &config.Root{MailboxNaming: config.LocalNaming}}
+
 	tests := map[string]string{
 		"common":          "user@example.com",
 		"with label":      "user+mailbox@example.com",
@@ -506,11 +512,9 @@ func TestRecipientAddress(t *testing.T) {
 		"multi-hop route": "@first.com,@second.com:user@example.com",
 	}
 
-	apolicy := policy.Addressing{Config: &config.Root{MailboxNaming: config.LocalNaming}}
-
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			r, err := apolicy.NewRecipient(tc)
+			r, err := localPolicy.NewRecipient(tc)
 			if err != nil {
 				t.Fatalf("Parse of %q failed: %v", tc, err)
 			}

--- a/pkg/policy/address_test.go
+++ b/pkg/policy/address_test.go
@@ -259,6 +259,18 @@ func TestExtractMailboxValid(t *testing.T) {
 			full:   "chars|}~@example.co.uk",
 			domain: "example.co.uk",
 		},
+		{
+			input:  "@host:user+label@domain.com",
+			local:  "user",
+			full:   "user@domain.com",
+			domain: "domain.com",
+		},
+		{
+			input:  "@a.com,@b.com:user+label@domain.com",
+			local:  "user",
+			full:   "user@domain.com",
+			domain: "domain.com",
+		},
 	}
 	for _, tc := range testTable {
 		if result, err := localPolicy.ExtractMailbox(tc.input); err != nil {
@@ -438,11 +450,10 @@ func TestRecipientAddress(t *testing.T) {
 		"common":        "user@example.com",
 		"with label":    "user+mailbox@example.com",
 		"special chars": "a!#$%&'*+-/=?^_`{|}~@example.com",
-		// "quoted string":   `"one two@three"@example.com`,
 		// "ipv4":            "user@[127.0.0.1]",
-		// "route host":      "@host:user@example.com",
-		// "route domain":    "@route.com:user@example.com",
-		// "multi-hop route": "@first.com,@second.com:user@example.com",
+		"route host":      "@host:user@example.com",
+		"route domain":    "@route.com:user@example.com",
+		"multi-hop route": "@first.com,@second.com:user@example.com",
 	}
 
 	apolicy := policy.Addressing{Config: &config.Root{MailboxNaming: config.LocalNaming}}

--- a/pkg/policy/address_test.go
+++ b/pkg/policy/address_test.go
@@ -447,6 +447,9 @@ func TestValidateLocal(t *testing.T) {
 		{"$A12345", true, "RFC3696 test case should be valid"},
 		{"!def!xyz%abc", true, "RFC3696 test case should be valid"},
 		{"_somename", true, "RFC3696 test case should be valid"},
+		{"@host:mailbox", true, "Forward-path routes are valid"},
+		{"@a.com,@b.com:mailbox", true, "Multi-hop forward-path routes are valid"},
+		{"@a.com,mailbox", false, "Unterminated forward-path routes are invalid"},
 	}
 	for _, tt := range testTable {
 		_, _, err := policy.ParseEmailAddress(tt.input + "@domain.com")

--- a/pkg/policy/address_test.go
+++ b/pkg/policy/address_test.go
@@ -430,3 +430,33 @@ func TestValidateLocal(t *testing.T) {
 		}
 	}
 }
+
+// TestRecipientAddress verifies the Recipient.Address values returned by Addressing.NewRecipient.
+// This function parses a RCPT TO path, not a To header. See rfc5321#section-4.1.2
+func TestRecipientAddress(t *testing.T) {
+	tests := map[string]string{
+		"common":        "user@example.com",
+		"with label":    "user+mailbox@example.com",
+		"special chars": "a!#$%&'*+-/=?^_`{|}~@example.com",
+		// "quoted string":   `"one two@three"@example.com`,
+		// "ipv4":            "user@[127.0.0.1]",
+		// "route host":      "@host:user@example.com",
+		// "route domain":    "@route.com:user@example.com",
+		// "multi-hop route": "@first.com,@second.com:user@example.com",
+	}
+
+	apolicy := policy.Addressing{Config: &config.Root{MailboxNaming: config.LocalNaming}}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			r, err := apolicy.NewRecipient(tc)
+			if err != nil {
+				t.Fatalf("Parse of %q failed: %v", tc, err)
+			}
+
+			if got, want := r.Address.Address, tc; got != want {
+				t.Errorf("Got Address: %q, want: %q", got, want)
+			}
+		})
+	}
+}

--- a/pkg/policy/address_test.go
+++ b/pkg/policy/address_test.go
@@ -309,6 +309,36 @@ func TestExtractMailboxValid(t *testing.T) {
 	}
 }
 
+// Test special cases with domain addressing mode.
+func TestExtractDomainMailboxValid(t *testing.T) {
+	domainPolicy := policy.Addressing{Config: &config.Root{MailboxNaming: config.DomainNaming}}
+
+	tests := map[string]struct {
+		input  string // Input to test
+		domain string // Expected output when mailbox naming = domain
+	}{
+		"ipv4": {
+			input:  "[127.0.0.1]",
+			domain: "[127.0.0.1]",
+		},
+		"medium ipv6": {
+			input:  "[IPv6:2001:db8:aaaa:1::100]",
+			domain: "[IPv6:2001:db8:aaaa:1::100]",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if result, err := domainPolicy.ExtractMailbox(tc.input); tc.domain != "" && err != nil {
+				t.Errorf("Error while parsing with domain naming %q: %v", tc.input, err)
+			} else {
+				if result != tc.domain {
+					t.Errorf("Parsing %q, expected %q, got %q", tc.input, tc.domain, result)
+				}
+			}
+		})
+	}
+}
+
 func TestExtractMailboxInvalid(t *testing.T) {
 	localPolicy := policy.Addressing{Config: &config.Root{MailboxNaming: config.LocalNaming}}
 	fullPolicy := policy.Addressing{Config: &config.Root{MailboxNaming: config.FullNaming}}

--- a/pkg/server/smtp/handler_test.go
+++ b/pkg/server/smtp/handler_test.go
@@ -266,6 +266,8 @@ func TestMailState(t *testing.T) {
 		{"RSET", 250},
 		{"MAIL FROM:<john@gmail.com>", 250},
 		{`RCPT TO:<"first/last"@host.com`, 250},
+		{"RCPT TO:<u1@[127.0.0.1]>", 250},
+		{"RCPT TO:<u1@[IPv6:2001:db8:aaaa:1::100]>", 250},
 	}
 	if err := playSession(t, server, script); err != nil {
 		t.Error(err)

--- a/pkg/test/testdata/no-to-ipv4.golden
+++ b/pkg/test/testdata/no-to-ipv4.golden
@@ -1,0 +1,12 @@
+Mailbox: ip4recipient
+From: <fromuser@inbucket.org>
+To: [<ip4recipient@[192.168.123.123]>]
+Subject: basic subject
+Size: 198
+
+BODY TEXT:
+No-To message.
+
+
+BODY HTML:
+

--- a/pkg/test/testdata/no-to-ipv6.golden
+++ b/pkg/test/testdata/no-to-ipv6.golden
@@ -1,0 +1,12 @@
+Mailbox: ip6recipient
+From: <fromuser@inbucket.org>
+To: [<ip6recipient@[IPv6:2001:0db8:85a3:0000:0000:8a2e:0370:7334]>]
+Subject: basic subject
+Size: 227
+
+BODY TEXT:
+No-To message.
+
+
+BODY HTML:
+

--- a/pkg/test/testdata/no-to.txt
+++ b/pkg/test/testdata/no-to.txt
@@ -1,0 +1,4 @@
+From: fromuser@inbucket.org
+Subject: basic subject
+
+No-To message.


### PR DESCRIPTION
Handle IP address domains for #243.  Also adds support for forward-path routes in RCPT TO.

Given both of these rework how RCPT TO addresses are parsed, this PR has potential for unintended consequences.
