### PR TITLE
Refactor SMTP handler_test log collection

### DIFF
--- a/pkg/server/smtp/handler.go
+++ b/pkg/server/smtp/handler.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/inbucket/inbucket/pkg/policy"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 )
 
 // State tracks the current mode of our SMTP state machine.
@@ -144,8 +143,8 @@ func (s *Session) String() string {
  *  4. If bad cmd, respond error
  *  5. Goto 2
  */
-func (s *Server) startSession(id int, conn net.Conn) {
-	logger := log.Hook(logHook{}).With().
+func (s *Server) startSession(id int, conn net.Conn, logger zerolog.Logger) {
+	logger = logger.Hook(logHook{}).With().
 		Str("module", "smtp").
 		Str("remote", conn.RemoteAddr().String()).
 		Int("session", id).Logger()

--- a/pkg/server/smtp/handler_test.go
+++ b/pkg/server/smtp/handler_test.go
@@ -26,6 +26,7 @@ type scriptStep struct {
 func TestGreetState(t *testing.T) {
 	ds := test.NewStore()
 	server := setupSMTPServer(ds)
+	defer server.Drain() // Required to prevent test logging data race.
 
 	// Test out some mangled HELOs
 	script := []scriptStep{
@@ -74,13 +75,13 @@ func TestGreetState(t *testing.T) {
 		t.Error(err)
 	}
 
-	server.Drain() // Required to prevent test logging data race.
 }
 
 // Test commands in READY state
 func TestEmptyEnvelope(t *testing.T) {
 	ds := test.NewStore()
 	server := setupSMTPServer(ds)
+	defer server.Drain()
 
 	// Test out some empty envelope without blanks
 	script := []scriptStep{
@@ -99,14 +100,13 @@ func TestEmptyEnvelope(t *testing.T) {
 	if err := playSession(t, server, script); err != nil {
 		t.Error(err)
 	}
-
-	server.Drain()
 }
 
 // Test AUTH
 func TestAuth(t *testing.T) {
 	ds := test.NewStore()
 	server := setupSMTPServer(ds)
+	defer server.Drain()
 
 	// PLAIN AUTH
 	script := []scriptStep{
@@ -137,14 +137,13 @@ func TestAuth(t *testing.T) {
 	if err := playSession(t, server, script); err != nil {
 		t.Error(err)
 	}
-
-	server.Drain()
 }
 
 // Test commands in READY state
 func TestReadyState(t *testing.T) {
 	ds := test.NewStore()
 	server := setupSMTPServer(ds)
+	defer server.Drain()
 
 	// Test out some mangled READY commands
 	script := []scriptStep{
@@ -203,14 +202,13 @@ func TestReadyState(t *testing.T) {
 	if err := playSession(t, server, script); err != nil {
 		t.Error(err)
 	}
-
-	server.Drain()
 }
 
 // Test commands in MAIL state
 func TestMailState(t *testing.T) {
 	mds := test.NewStore()
 	server := setupSMTPServer(mds)
+	defer server.Drain()
 
 	// Test out some mangled READY commands
 	script := []scriptStep{
@@ -311,14 +309,13 @@ func TestMailState(t *testing.T) {
 	if err := playSession(t, server, script); err != nil {
 		t.Error(err)
 	}
-
-	server.Drain()
 }
 
 // Test commands in DATA state
 func TestDataState(t *testing.T) {
 	mds := test.NewStore()
 	server := setupSMTPServer(mds)
+	defer server.Drain()
 
 	var script []scriptStep
 	pipe := setupSMTPSession(t, server)
@@ -382,8 +379,6 @@ Hi!
 	}
 	_, _ = c.Cmd("QUIT")
 	_, _, _ = c.ReadCodeLine(221)
-
-	server.Drain()
 }
 
 // playSession creates a new session, reads the greeting and then plays the script

--- a/pkg/server/smtp/handler_test.go
+++ b/pkg/server/smtp/handler_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 
-	"log"
 	"net"
 	"net/textproto"
 	"os"
@@ -17,6 +16,7 @@ import (
 	"github.com/inbucket/inbucket/pkg/policy"
 	"github.com/inbucket/inbucket/pkg/storage"
 	"github.com/inbucket/inbucket/pkg/test"
+	"github.com/rs/zerolog/log"
 )
 
 type scriptStep struct {
@@ -482,7 +482,7 @@ func setupSMTPServer(ds storage.Store) (s *Server, buf *bytes.Buffer, teardown f
 	}
 	// Capture log output.
 	buf = new(bytes.Buffer)
-	log.SetOutput(buf)
+	// log.SetOutput(buf)
 	// Create a server, don't start it.
 	// TODO Remove teardown.
 	teardown = func() {}
@@ -500,6 +500,6 @@ func setupSMTPSession(server *Server) net.Conn {
 	// Start the session.
 	server.wg.Add(1)
 	sessionNum++
-	go server.startSession(sessionNum, &mockConn{serverConn})
+	go server.startSession(sessionNum, &mockConn{serverConn}, log.Logger)
 	return clientConn
 }

--- a/pkg/server/smtp/listener.go
+++ b/pkg/server/smtp/listener.go
@@ -170,7 +170,7 @@ func (s *Server) serve(ctx context.Context) {
 			tempDelay = 0
 			expConnectsTotal.Add(1)
 			s.wg.Add(1)
-			go s.startSession(sessionID, conn)
+			go s.startSession(sessionID, conn, log.Logger)
 		}
 	}
 }


### PR DESCRIPTION
Debugging SMTP handler sessions is difficult, as all the logs for all tests were being sent to the terminal when any test failed.  This change uses zerolog functionality to collect logs for a particular test and log it to testing.T.

- smtp: allow logger to be passed into startSession
- smtp: remove logbuf and teardown from handler_test
- smtp: handler_test log output to testing.T
