### PR TITLE
Break up handler tests

### DIFF
--- a/cmd/inbucket/main.go
+++ b/cmd/inbucket/main.go
@@ -145,9 +145,13 @@ signalLoop:
 
 	// Wait for active connections to finish.
 	go timedExit(*pidfile)
+	log.Debug().Str("phase", "shutdown").Msg("Draining SMTP connections")
 	services.SMTPServer.Drain()
+	log.Debug().Str("phase", "shutdown").Msg("Draining POP3 connections")
 	services.POP3Server.Drain()
+	log.Debug().Str("phase", "shutdown").Msg("Checking retention scanner is stopped")
 	services.RetentionScanner.Join()
+
 	removePIDFile(*pidfile)
 	closeLog()
 }

--- a/pkg/server/smtp/listener.go
+++ b/pkg/server/smtp/listener.go
@@ -179,7 +179,6 @@ func (s *Server) serve(ctx context.Context) {
 func (s *Server) Drain() {
 	// Wait for sessions to close.
 	s.wg.Wait()
-	log.Debug().Str("module", "smtp").Str("phase", "shutdown").Msg("SMTP connections have drained")
 }
 
 // Notify allows the running SMTP server to be monitored for a fatal error.


### PR DESCRIPTION
- Do drain logging from main to reduce test output
- smtp: Break up some of the larger handler test funcs
