### PR TITLE
smtp: Adjust fromRegex to handle AUTH=<> in middle of args

### DIFF
--- a/pkg/server/smtp/handler.go
+++ b/pkg/server/smtp/handler.go
@@ -57,7 +57,7 @@ const (
 // as quoted pair and in double quoted strings (?i) makes the regex case insensitive, (?:) is
 // non-grouping sub-match.  Accepts empty angle bracket value in options for 'AUTH=<>'.
 var fromRegex = regexp.MustCompile(
-	`(?i)^FROM:\s*<((?:(?:\\>|[^>])+|"[^"]+"@[^>])+)?>( [\w= ]+(?:=<>)?)?$`)
+	`(?i)^FROM:\s*<((?:(?:\\>|[^>])+|"[^"]+"@[^>])+)?>( ([\w= ]|=<>)+)?$`)
 
 func (s State) String() string {
 	switch s {
@@ -618,7 +618,7 @@ func (s *Session) parseCmd(line string) (cmd string, arg string, ok bool) {
 // The leading space is mandatory.
 func (s *Session) parseArgs(arg string) (args map[string]string, ok bool) {
 	args = make(map[string]string)
-	re := regexp.MustCompile(` (\w+)=(\w+)`)
+	re := regexp.MustCompile(` (\w+)=(\w+|<>)`)
 	pm := re.FindAllStringSubmatch(arg, -1)
 	if pm == nil {
 		s.logger.Warn().Msgf("Failed to parse arg string: %q", arg)

--- a/pkg/server/smtp/handler_test.go
+++ b/pkg/server/smtp/handler_test.go
@@ -172,6 +172,7 @@ func TestReadyStateValidCommands(t *testing.T) {
 		{"MAIL FROM:<john@gmail.com> SIZE=1024", 250},
 		{"MAIL FROM:<john@gmail.com> SIZE=1024 BODY=8BITMIME", 250},
 		{"MAIL FROM:<bounces@onmicrosoft.com> SIZE=4096 AUTH=<>", 250},
+		{"MAIL FROM:<b@o.com> SIZE=4096 AUTH=<> BODY=7BIT", 250},
 		{"MAIL FROM:<host!host!user/data@foo.com>", 250},
 		{"MAIL FROM:<\"first last\"@space.com>", 250},
 		{"MAIL FROM:<user\\@internal@external.com>", 250},


### PR DESCRIPTION
Previously inbucket only recognized AUTH=<> at the end of the RCPT FROM arg
list, this was an error.  Should resolve #283

Signed-off-by: James Hillyerd <james@hillyerd.com>
