### PR TITLE
lua: Use table syntax for user object bindings

### DIFF
--- a/pkg/extension/luahost/bind_address.go
+++ b/pkg/extension/luahost/bind_address.go
@@ -48,8 +48,8 @@ func unwrapMailAddress(ud *lua.LUserData) (*mail.Address, bool) {
 	return val, ok
 }
 
-func checkMailAddress(ls *lua.LState) *mail.Address {
-	ud := ls.CheckUserData(1)
+func checkMailAddress(ls *lua.LState, pos int) *mail.Address {
+	ud := ls.CheckUserData(pos)
 	if val, ok := ud.Value.(*mail.Address); ok {
 		return val
 	}
@@ -58,7 +58,7 @@ func checkMailAddress(ls *lua.LState) *mail.Address {
 }
 
 func mailAddressGetSetAddress(ls *lua.LState) int {
-	val := checkMailAddress(ls)
+	val := checkMailAddress(ls, 1)
 	if ls.GetTop() == 2 {
 		// Setter.
 		val.Address = ls.CheckString(2)
@@ -71,7 +71,7 @@ func mailAddressGetSetAddress(ls *lua.LState) int {
 }
 
 func mailAddressGetSetName(ls *lua.LState) int {
-	val := checkMailAddress(ls)
+	val := checkMailAddress(ls, 1)
 	if ls.GetTop() == 2 {
 		// Setter.
 		val.Name = ls.CheckString(2)

--- a/pkg/extension/luahost/lua_test.go
+++ b/pkg/extension/luahost/lua_test.go
@@ -40,12 +40,12 @@ func TestAfterMessageStored(t *testing.T) {
 			assert_eq(msg.subject, "subj1")
 			assert_eq(msg.size, 42)
 
-			assert_eq(msg.from:name(), "name1")
-			assert_eq(msg.from:address(), "addr1")
+			assert_eq(msg.from.name, "name1")
+			assert_eq(msg.from.address, "addr1")
 
 			assert_eq(table.getn(msg.to), 1)
-			assert_eq(msg.to[1]:name(), "name2")
-			assert_eq(msg.to[1]:address(), "addr2")
+			assert_eq(msg.to[1].name, "name2")
+			assert_eq(msg.to[1].address, "addr2")
 
 			assert_eq(msg.date, 981173106)
 

--- a/pkg/extension/luahost/lua_test.go
+++ b/pkg/extension/luahost/lua_test.go
@@ -35,19 +35,19 @@ func TestAfterMessageStored(t *testing.T) {
 		end
 
 		function after_message_stored(msg)
-			assert_eq(msg:mailbox(), "mb1")
-			assert_eq(msg:id(), "id1")
-			assert_eq(msg:subject(), "subj1")
-			assert_eq(msg:size(), 42)
+			assert_eq(msg.mailbox, "mb1")
+			assert_eq(msg.id, "id1")
+			assert_eq(msg.subject, "subj1")
+			assert_eq(msg.size, 42)
 
-			assert_eq(msg:from():name(), "name1")
-			assert_eq(msg:from():address(), "addr1")
+			assert_eq(msg.from:name(), "name1")
+			assert_eq(msg.from:address(), "addr1")
 
-			assert_eq(table.getn(msg:to()), 1)
-			assert_eq(msg:to()[1]:name(), "name2")
-			assert_eq(msg:to()[1]:address(), "addr2")
+			assert_eq(table.getn(msg.to), 1)
+			assert_eq(msg.to[1]:name(), "name2")
+			assert_eq(msg.to[1]:address(), "addr2")
 
-			assert_eq(msg:date(), 981173106)
+			assert_eq(msg.date, 981173106)
 
 			notify:send(test_ok)
 		end


### PR DESCRIPTION
- lua: update bind_message to use table syntax
- lua: update bind_address to use table syntax
