### PR TITLE
goreleaser: correct archive naming by using default

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,8 +50,6 @@ archives:
   - id: tarball
     format: tar.gz
     wrap_in_directory: true
-    name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{
-      .Arm }}{{ end }}'
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
.Binary was causing some archives to be called inbucket_client

For #341 and just correctness in general

Signed-off-by: James Hillyerd <james@hillyerd.com>
