### PR TITLE
Don't do server-side handshake explicitly...

### DIFF
--- a/pkg/server/pop3/handler.go
+++ b/pkg/server/pop3/handler.go
@@ -2,7 +2,6 @@ package pop3
 
 import (
 	"bufio"
-	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -110,14 +109,6 @@ func (s *Server) startSession(id int, conn net.Conn) {
 	if s.config.ForceTLS {
 		logger.Debug().Msg("Setting up TLS for ForceTLS")
 		tlsConn := tls.Server(conn, s.tlsConfig)
-		toCtx, toCtxCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer toCtxCancel()
-		if err := tlsConn.HandshakeContext(toCtx); err != nil {
-			logger.Error().Msgf("TLS handshake failed: %v.", err)
-			conn.Close()
-			s.wg.Done()
-			return
-		}
 		s.tlsState = new(tls.ConnectionState)
 		*s.tlsState = tlsConn.ConnectionState()
 		conn = tlsConn


### PR DESCRIPTION
when we are doing TLS at the inception. It only causes timeout problems. The handshake will happen at the first read.