### PR TITLE
goreleaser: use default snapshot name template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,9 +81,6 @@ nfpms:
         dst: "/etc/inbucket/greeting.html"
         type: config|noreplace
 
-snapshot:
-  name_template: SNAPSHOT-{{ .Commit }}
-
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_checksums.txt'
 


### PR DESCRIPTION
Our manually configured template was breaking debian package snapshots,
version must start with a number
