### PR TITLE
goreleaser: remove deprecated rlcp option

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,7 +48,6 @@ builds:
 
 archives:
   - id: tarball
-    rlcp: true
     format: tar.gz
     wrap_in_directory: true
     format_overrides:


### PR DESCRIPTION
Fixes #389

Signed-off-by: James Hillyerd <james@hillyerd.com>
