### PR TITLE
Add a ForceTLS flag for SMTP.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -90,6 +90,7 @@ type SMTP struct {
 	TLSPrivKey          string        `default:"cert.key" desc:"X509 Private Key file for TLS Support"`
 	TLSCert             string        `default:"cert.crt" desc:"X509 Public Certificate file for TLS Support"`
 	Debug               bool          `ignored:"true"`
+	ForceTLS            bool          `default:"false" desc:"Listen for connections with TLS."`
 }
 
 // POP3 contains the POP3 server configuration.

--- a/pkg/server/smtp/listener.go
+++ b/pkg/server/smtp/listener.go
@@ -113,7 +113,11 @@ func (s *Server) Start(ctx context.Context, readyFunc func()) {
 		return
 	}
 	slog.Info().Str("addr", addr.String()).Msg("SMTP listening on tcp4")
-	s.listener, err = net.ListenTCP("tcp4", addr)
+	if s.config.ForceTLS {
+		s.listener, err = tls.Listen("tcp4", addr.String(), s.tlsConfig)
+	} else {
+		s.listener, err = net.ListenTCP("tcp4", addr)
+	}
 	if err != nil {
 		slog.Error().Err(err).Msg("Failed to start tcp4 listener")
 		s.notify <- err


### PR DESCRIPTION
When this is enabled, the server listens with TLS instead of waiting for STARTTLS.