### PR TITLE
UTC format timestamps in headers (#404)

### DIFF
--- a/pkg/server/smtp/handler.go
+++ b/pkg/server/smtp/handler.go
@@ -533,7 +533,7 @@ func (s *Session) dataHandler() {
 	mailData := bytes.NewBuffer(msgBuf)
 
 	// Mail data complete.
-	tstamp := time.Now().Format(timeStampFormat)
+	tstamp := time.Now().UTC().Format(timeStampFormat)
 	for _, recip := range s.recipients {
 		if recip.ShouldStore() {
 			// Generate Received header.


### PR DESCRIPTION
This change makes all header timestamps (e.g. "Received") to use
UTC time zone.

This way the length of such headers do not depend on local time zone
which if effect fixes https://github.com/inbucket/inbucket/issues/404.