### PR TITLE
docker: don't build until after PR submitted

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,7 +6,10 @@ on:
       - main
     tags:
       - 'v*'
-  pull_request:
+  pull_request_review:
+    types:
+      - submitted
+  workflow_dispatch: # allow for manual run
 
 jobs:
   build:


### PR DESCRIPTION
Docker builds, particularly ARM, take a long time.  This workflow change should
allow them to be run manually, and automatically after a PR is submitted.
