### PR TITLE
extension: BeforeMessageStored event to rewrite envelope

### DIFF
--- a/pkg/extension/broker.go
+++ b/pkg/extension/broker.go
@@ -6,7 +6,7 @@ import (
 
 // EventBroker maintains a list of listeners interested in a specific type
 // of event.
-type EventBroker[E any, R comparable] struct {
+type EventBroker[E any, R interface{}] struct {
 	sync.RWMutex
 	listenerNames []string     // Ordered listener names.
 	listenerFuncs []func(E) *R // Ordered listener functions.

--- a/pkg/extension/event/events.go
+++ b/pkg/extension/event/events.go
@@ -11,6 +11,15 @@ type AddressParts struct {
 	Domain string
 }
 
+// InboundMessage contains the basic header and mailbox data for a message being received.
+type InboundMessage struct {
+	Mailboxes []string
+	From      mail.Address
+	To        []mail.Address
+	Subject   string
+	Size      int64
+}
+
 // MessageMetadata contains the basic header data for a message event.
 type MessageMetadata struct {
 	Mailbox string

--- a/pkg/extension/host.go
+++ b/pkg/extension/host.go
@@ -23,6 +23,7 @@ type Events struct {
 	AfterMessageDeleted AsyncEventBroker[event.MessageMetadata]
 	AfterMessageStored  AsyncEventBroker[event.MessageMetadata]
 	BeforeMailAccepted  EventBroker[event.AddressParts, bool]
+	BeforeMessageStored EventBroker[event.InboundMessage, event.InboundMessage]
 }
 
 // Void indicates the event emitter will ignore any value returned by listeners.

--- a/pkg/message/manager.go
+++ b/pkg/message/manager.go
@@ -84,7 +84,7 @@ func (s *StoreManager) Deliver(
 
 	inbound := &event.InboundMessage{
 		Mailboxes: mailboxes,
-		From:      from.Address,
+		From:      *fromaddr[0],
 		To:        toAddrs,
 		Subject:   subject,
 		Size:      int64(len(source)),
@@ -103,6 +103,10 @@ func (s *StoreManager) Deliver(
 	} else {
 		// Event response overrides destination mailboxes and address policy.
 		inbound = extResult
+		toaddr = make([]*mail.Address, len(inbound.To))
+		for i := range inbound.To {
+			toaddr[i] = &inbound.To[i]
+		}
 	}
 
 	// Deliver to mailboxes.
@@ -115,10 +119,10 @@ func (s *StoreManager) Deliver(
 		delivery := &Delivery{
 			Meta: event.MessageMetadata{
 				Mailbox: mb,
-				From:    fromaddr[0],
+				From:    &inbound.From,
 				To:      toaddr,
 				Date:    now,
-				Subject: subject,
+				Subject: inbound.Subject,
 			},
 			Reader: io.MultiReader(strings.NewReader(recvd), bytes.NewReader(source)),
 		}

--- a/pkg/message/manager.go
+++ b/pkg/message/manager.go
@@ -82,7 +82,7 @@ func (s *StoreManager) Deliver(
 		toAddrs[i] = recip.Address
 	}
 
-	inbound := event.InboundMessage{
+	inbound := &event.InboundMessage{
 		Mailboxes: mailboxes,
 		From:      from.Address,
 		To:        toAddrs,
@@ -90,40 +90,48 @@ func (s *StoreManager) Deliver(
 		Size:      int64(len(source)),
 	}
 
-	extResult := s.ExtHost.Events.BeforeMessageStored.Emit(&inbound)
-	if extResult != nil {
-		inbound = *extResult
+	extResult := s.ExtHost.Events.BeforeMessageStored.Emit(inbound)
+	if extResult == nil {
+		// Use address policy to determine deliverable mailboxes.
+		mailboxes = mailboxes[:0]
+		for _, recip := range recipients {
+			if recip.ShouldStore() {
+				mailboxes = append(mailboxes, recip.Mailbox)
+			}
+		}
+		inbound.Mailboxes = mailboxes
+	} else {
+		// Event response overrides destination mailboxes and address policy.
+		inbound = extResult
 	}
 
 	// Deliver to mailboxes.
-	for _, recip := range recipients {
-		if recip.ShouldStore() {
-			// Append recipient and timestamp to generated Recieved header.
-			recvd := fmt.Sprintf("%s  for <%s>; %s\r\n", recvdHeader, recip.Address.Address, tstamp)
+	for _, mb := range inbound.Mailboxes {
+		// Append recipient and timestamp to generated Recieved header.
+		recvd := fmt.Sprintf("%s  for <%s>; %s\r\n", recvdHeader, mb, tstamp)
 
-			// Deliver message.
-			logger.Debug().Str("mailbox", recip.Mailbox).Msg("Delivering message")
-			delivery := &Delivery{
-				Meta: event.MessageMetadata{
-					Mailbox: recip.Mailbox,
-					From:    fromaddr[0],
-					To:      toaddr,
-					Date:    now,
-					Subject: subject,
-				},
-				Reader: io.MultiReader(strings.NewReader(recvd), bytes.NewReader(source)),
-			}
-			id, err := s.Store.AddMessage(delivery)
-			if err != nil {
-				logger.Error().Str("mailbox", recip.Mailbox).Err(err).Msg("Delivery failed")
-				return err
-			}
-
-			// Emit message stored event.
-			event := delivery.Meta
-			event.ID = id
-			s.ExtHost.Events.AfterMessageStored.Emit(&event)
+		// Deliver message.
+		logger.Debug().Str("mailbox", mb).Msg("Delivering message")
+		delivery := &Delivery{
+			Meta: event.MessageMetadata{
+				Mailbox: mb,
+				From:    fromaddr[0],
+				To:      toaddr,
+				Date:    now,
+				Subject: subject,
+			},
+			Reader: io.MultiReader(strings.NewReader(recvd), bytes.NewReader(source)),
 		}
+		id, err := s.Store.AddMessage(delivery)
+		if err != nil {
+			logger.Error().Str("mailbox", mb).Err(err).Msg("Delivery failed")
+			return err
+		}
+
+		// Emit message stored event.
+		event := delivery.Meta
+		event.ID = id
+		s.ExtHost.Events.AfterMessageStored.Emit(&event)
 	}
 
 	return nil

--- a/pkg/message/manager_test.go
+++ b/pkg/message/manager_test.go
@@ -1,10 +1,12 @@
 package message_test
 
 import (
+	"net/mail"
 	"testing"
 
 	"github.com/inbucket/inbucket/v3/pkg/config"
 	"github.com/inbucket/inbucket/v3/pkg/extension"
+	"github.com/inbucket/inbucket/v3/pkg/extension/event"
 	"github.com/inbucket/inbucket/v3/pkg/message"
 	"github.com/inbucket/inbucket/v3/pkg/policy"
 	"github.com/inbucket/inbucket/v3/pkg/test"
@@ -52,12 +54,48 @@ func TestDeliverRespectsRecipientPolicy(t *testing.T) {
 	assertMessageCount(t, sm, "u2@example.com", 1)
 }
 
+func TestDeliverEmitsBeforeMessageStoredEvent(t *testing.T) {
+	sm, extHost := testStoreManager()
+
+	// Register function to receive event.
+	var got *event.InboundMessage
+	extHost.Events.BeforeMessageStored.AddListener(
+		"test",
+		func(msg event.InboundMessage) *event.InboundMessage {
+			got = &msg
+			return nil
+		})
+
+	// Deliver a message to trigger event.
+	origin, _ := sm.AddrPolicy.ParseOrigin("from@example.com")
+	recip1, _ := sm.AddrPolicy.NewRecipient("u1@example.com")
+	recip2, _ := sm.AddrPolicy.NewRecipient("u2@example.com")
+	if err := sm.Deliver(
+		origin,
+		[]*policy.Recipient{recip1, recip2},
+		"Received: xyz\n",
+		[]byte("From: from@example.com\nSubject: tsub\n\ntest email"),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	require.NotNil(t, got, "BeforeMessageStored listener did not receive InboundMessage")
+	assert.Equal(t, []string{"u1@example.com", "u2@example.com"}, got.Mailboxes, "Mailboxes not equal")
+	assert.Equal(t, mail.Address{Name: "", Address: "from@example.com"}, got.From, "From not equal")
+	assert.Equal(t, []mail.Address{
+		{Name: "", Address: "u1@example.com"},
+		{Name: "", Address: "u2@example.com"},
+	}, got.To, "To not equal")
+	assert.Equal(t, "tsub", got.Subject, "Subject not equal")
+	assert.Equal(t, int64(48), got.Size, "Size not equal")
+}
+
 func TestDeliverEmitsAfterMessageStoredEvent(t *testing.T) {
 	sm, extHost := testStoreManager()
 
 	listener := extHost.Events.AfterMessageStored.AsyncTestListener("manager", 1)
 
-	// Attempt to deliver a message to generate event.
+	// Deliver a message to trigger event.
 	origin, _ := sm.AddrPolicy.ParseOrigin("from@example.com")
 	recip, _ := sm.AddrPolicy.NewRecipient("to@example.com")
 	if err := sm.Deliver(

--- a/pkg/server/smtp/handler_test.go
+++ b/pkg/server/smtp/handler_test.go
@@ -589,7 +589,7 @@ func setupSMTPServer(ds storage.Store, extHost *extension.Host) *Server {
 
 	// Create a server, don't start it.
 	addrPolicy := &policy.Addressing{Config: cfg}
-	manager := &message.StoreManager{Store: ds}
+	manager := &message.StoreManager{Store: ds, ExtHost: extHost}
 
 	return NewServer(cfg.SMTP, manager, addrPolicy, extHost)
 }

--- a/pkg/test/testdata/basic.golden
+++ b/pkg/test/testdata/basic.golden
@@ -2,7 +2,7 @@ Mailbox: recipient
 From: <fromuser@inbucket.org>
 To: [<recipient@inbucket.org>]
 Subject: basic subject
-Size: 217
+Size: 204
 
 BODY TEXT:
 Basic message.

--- a/pkg/test/testdata/encodedheader.golden
+++ b/pkg/test/testdata/encodedheader.golden
@@ -2,7 +2,7 @@ Mailbox: recipient
 From: X-äéß Y-äéß <fromuser@inbucket.org>
 To: [Test of ȇɲʢȯȡɪɴʛ <recipient@inbucket.org>]
 Subject: Test of ȇɲʢȯȡɪɴʛ
-Size: 351
+Size: 338
 
 BODY TEXT:
 Basic message.

--- a/pkg/test/testdata/fullname.golden
+++ b/pkg/test/testdata/fullname.golden
@@ -2,7 +2,7 @@ Mailbox: recipient
 From: From User <fromuser@inbucket.org>
 To: [Rec I. Pient <recipient@inbucket.org>]
 Subject: basic subject
-Size: 246
+Size: 233
 
 BODY TEXT:
 Basic message.

--- a/pkg/test/testdata/no-to-ipv4.golden
+++ b/pkg/test/testdata/no-to-ipv4.golden
@@ -2,7 +2,7 @@ Mailbox: ip4recipient
 From: <fromuser@inbucket.org>
 To: [<ip4recipient@[192.168.123.123]>]
 Subject: basic subject
-Size: 198
+Size: 180
 
 BODY TEXT:
 No-To message.

--- a/pkg/test/testdata/no-to-ipv6.golden
+++ b/pkg/test/testdata/no-to-ipv6.golden
@@ -2,7 +2,7 @@ Mailbox: ip6recipient
 From: <fromuser@inbucket.org>
 To: [<ip6recipient@[IPv6:2001:0db8:85a3:0000:0000:8a2e:0370:7334]>]
 Subject: basic subject
-Size: 227
+Size: 180
 
 BODY TEXT:
 No-To message.


### PR DESCRIPTION
- extension: add InboundMessage type and bindings
- manager: fires BeforeMessageStored event
- manager: Reacts to BeforeMessageStored event response
- manager: Apply BeforeMessageStored response fields to message

Closes #408
