### PR TITLE
docker-build action: only push to registry on main branch and v* tag pushes

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,6 +11,9 @@ on:
       - submitted
   workflow_dispatch: # allow for manual run
 
+env:
+  REGISTRY_PUSH: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+
 jobs:
   build:
     name: 'Build Container'
@@ -44,14 +47,14 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+        if: $REGISTRY_PUSH
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
+        if: $REGISTRY_PUSH
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -63,6 +66,6 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64, linux/arm/v7
-          push: ${{ github.event_name != 'pull_request' }}
+          push: $REGISTRY_PUSH
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Signed-off-by: James Hillyerd <james@hillyerd.com>
