### PR TITLE
event: Use pointers for InboundMessage addresses

### DIFF
--- a/pkg/extension/event/events.go
+++ b/pkg/extension/event/events.go
@@ -14,8 +14,8 @@ type AddressParts struct {
 // InboundMessage contains the basic header and mailbox data for a message being received.
 type InboundMessage struct {
 	Mailboxes []string
-	From      mail.Address
-	To        []mail.Address
+	From      *mail.Address
+	To        []*mail.Address
 	Subject   string
 	Size      int64
 }

--- a/pkg/extension/luahost/bind_inboundmessage.go
+++ b/pkg/extension/luahost/bind_inboundmessage.go
@@ -73,12 +73,12 @@ func inboundMessageIndex(ls *lua.LState) int {
 		}
 		ls.Push(lt)
 	case "from":
-		ls.Push(wrapMailAddress(ls, &m.From))
+		ls.Push(wrapMailAddress(ls, m.From))
 	case "to":
 		lt := &lua.LTable{}
 		for _, v := range m.To {
 			addr := v
-			lt.Append(wrapMailAddress(ls, &addr))
+			lt.Append(wrapMailAddress(ls, addr))
 		}
 		ls.Push(lt)
 	case "subject":
@@ -110,15 +110,15 @@ func inboundMessageNewIndex(ls *lua.LState) int {
 		})
 		m.Mailboxes = mailboxes
 	case "from":
-		m.From = *checkMailAddress(ls, 3)
+		m.From = checkMailAddress(ls, 3)
 	case "to":
 		lt := ls.CheckTable(3)
-		to := make([]mail.Address, 0, 16)
+		to := make([]*mail.Address, 0, 16)
 		lt.ForEach(func(k, lv lua.LValue) {
 			if ud, ok := lv.(*lua.LUserData); ok {
 				// TODO should fail if wrong type + test.
 				if entry, ok := unwrapMailAddress(ud); ok {
-					to = append(to, *entry)
+					to = append(to, entry)
 				}
 			}
 		})

--- a/pkg/extension/luahost/bind_inboundmessage_test.go
+++ b/pkg/extension/luahost/bind_inboundmessage_test.go
@@ -31,8 +31,8 @@ const LuaInit = `
 func TestInboundMessageGetters(t *testing.T) {
 	want := &event.InboundMessage{
 		Mailboxes: []string{"mb1", "mb2"},
-		From:      mail.Address{Name: "name1", Address: "addr1"},
-		To: []mail.Address{
+		From:      &mail.Address{Name: "name1", Address: "addr1"},
+		To: []*mail.Address{
 			{Name: "name2", Address: "addr2"},
 			{Name: "name3", Address: "addr3"},
 		},
@@ -66,8 +66,8 @@ func TestInboundMessageGetters(t *testing.T) {
 func TestInboundMessageSetters(t *testing.T) {
 	want := &event.InboundMessage{
 		Mailboxes: []string{"mb1", "mb2"},
-		From:      mail.Address{Name: "name1", Address: "addr1"},
-		To: []mail.Address{
+		From:      &mail.Address{Name: "name1", Address: "addr1"},
+		To: []*mail.Address{
 			{Name: "name2", Address: "addr2"},
 			{Name: "name3", Address: "addr3"},
 		},

--- a/pkg/extension/luahost/lua_test.go
+++ b/pkg/extension/luahost/lua_test.go
@@ -179,8 +179,8 @@ func TestBeforeMessageStored(t *testing.T) {
 	// Event to send.
 	msg := event.InboundMessage{
 		Mailboxes: []string{"one", "two"},
-		From:      mail.Address{Name: "From Name", Address: "from@example.com"},
-		To: []mail.Address{
+		From:      &mail.Address{Name: "From Name", Address: "from@example.com"},
+		To: []*mail.Address{
 			{Name: "To1 Name", Address: "to1@example.com"},
 			{Name: "To2 Name", Address: "to2@example.com"},
 		},
@@ -233,8 +233,8 @@ func TestBeforeMessageStored(t *testing.T) {
 	// Verify response values.
 	want := &event.InboundMessage{
 		Mailboxes: []string{"resone", "restwo"},
-		From:      mail.Address{Name: "Res From", Address: "res@example.com"},
-		To: []mail.Address{
+		From:      &mail.Address{Name: "Res From", Address: "res@example.com"},
+		To: []*mail.Address{
 			{Name: "To1 Res", Address: "res1@example.com"},
 			{Name: "To2 Res", Address: "res2@example.com"},
 		},

--- a/pkg/message/manager_test.go
+++ b/pkg/message/manager_test.go
@@ -137,8 +137,8 @@ test email`),
 
 	require.NotNil(t, got, "BeforeMessageStored listener did not receive InboundMessage")
 	assert.Equal(t, []string{"u1@example.com", "u2@example.com"}, got.Mailboxes, "Mailboxes not equal")
-	assert.Equal(t, mail.Address{Name: "", Address: "from@example.com"}, got.From, "From not equal")
-	assert.Equal(t, []mail.Address{
+	assert.Equal(t, &mail.Address{Name: "", Address: "from@example.com"}, got.From, "From not equal")
+	assert.Equal(t, []*mail.Address{
 		{Name: "", Address: "u1@example.com"},
 		{Name: "", Address: "u3@external.com"},
 	}, got.To, "To not equal")
@@ -173,8 +173,8 @@ func TestDeliverEmitsBeforeMessageStoredEventRcptTo(t *testing.T) {
 
 	require.NotNil(t, got, "BeforeMessageStored listener did not receive InboundMessage")
 	assert.Equal(t, []string{"u1@example.com", "u2@example.com"}, got.Mailboxes, "Mailboxes not equal")
-	assert.Equal(t, mail.Address{Name: "", Address: "from@example.com"}, got.From, "From not equal")
-	assert.Equal(t, []mail.Address{
+	assert.Equal(t, &mail.Address{Name: "", Address: "from@example.com"}, got.From, "From not equal")
+	assert.Equal(t, []*mail.Address{
 		{Name: "", Address: "u1@example.com"},
 		{Name: "", Address: "u2@example.com"},
 	}, got.To, "To not equal")
@@ -256,10 +256,10 @@ func TestDeliverUsesBeforeMessageStoredEventResponseFields(t *testing.T) {
 		func(msg event.InboundMessage) *event.InboundMessage {
 			// Listener rewrites destination mailboxes.
 			msg.Subject = "event subj"
-			msg.From = mail.Address{Address: "from@event.com", Name: "From Event"}
+			msg.From = &mail.Address{Address: "from@event.com", Name: "From Event"}
 
 			// Changing To does not affect destination mailbox(es).
-			msg.To = []mail.Address{
+			msg.To = []*mail.Address{
 				{Address: "to@event.com", Name: "To Event"},
 				{Address: "to2@event.com", Name: "To 2 Event"},
 			}

--- a/pkg/message/manager_test.go
+++ b/pkg/message/manager_test.go
@@ -479,6 +479,17 @@ test email`
 	assert.Contains(t, got, msgSource, "Source should contain original message source")
 }
 
+func TestMailboxForAddress(t *testing.T) {
+	// Configured for FullNaming.
+	sm, _ := testStoreManager()
+
+	addr := "u1@example.com"
+	got, err := sm.MailboxForAddress(addr)
+	require.NoError(t, err)
+
+	assert.Equal(t, addr, got, "FullNaming mode should return a full address for mailbox")
+}
+
 // Returns an empty StoreManager and extension Host pair, configured for testing.
 func testStoreManager() (*message.StoreManager, *extension.Host) {
 	extHost := extension.NewHost()


### PR DESCRIPTION
To ease conversions to/from MessageMetadata

Signed-off-by: James Hillyerd <james@hillyerd.com>
