### PR TITLE
[Rest Client] Use options for client.New

### DIFF
--- a/pkg/rest/client/apiv1_client.go
+++ b/pkg/rest/client/apiv1_client.go
@@ -17,22 +17,22 @@ type Client struct {
 
 // New creates a new v1 REST API client given the base URL of an Inbucket server, ex:
 // "http://localhost:9000"
-func New(baseURL string, opts ...ClientOption) (*Client, error) {
+func New(baseURL string, opts ...Option) (*Client, error) {
 	parsedURL, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, err
 	}
 
-	clientOptions := getDefaultClientOptions()
+	mergedOpts := getDefaultOptions()
 	for _, opt := range opts {
-		opt.apply(clientOptions)
+		opt.apply(mergedOpts)
 	}
 
 	c := &Client{
 		restClient{
 			client: &http.Client{
-				Timeout:   clientOptions.timeout,
-				Transport: clientOptions.transport,
+				Timeout:   mergedOpts.timeout,
+				Transport: mergedOpts.transport,
 			},
 			baseURL: parsedURL,
 		},

--- a/pkg/rest/client/apiv1_client.go
+++ b/pkg/rest/client/apiv1_client.go
@@ -4,11 +4,9 @@ package client
 import (
 	"bytes"
 	"fmt"
+	"github.com/inbucket/inbucket/v3/pkg/rest/model"
 	"net/http"
 	"net/url"
-	"time"
-
-	"github.com/inbucket/inbucket/v3/pkg/rest/model"
 )
 
 // Client accesses the Inbucket REST API v1
@@ -18,15 +16,20 @@ type Client struct {
 
 // New creates a new v1 REST API client given the base URL of an Inbucket server, ex:
 // "http://localhost:9000"
-func New(baseURL string) (*Client, error) {
+func New(baseURL string, optionFuncs ...func(*ClientOptions)) (*Client, error) {
 	parsedURL, err := url.Parse(baseURL)
+	clientOptions := getDefaultClientOptions()
+	for _, optionFunc := range optionFuncs {
+		optionFunc(clientOptions)
+	}
 	if err != nil {
 		return nil, err
 	}
 	c := &Client{
 		restClient{
 			client: &http.Client{
-				Timeout: 30 * time.Second,
+				Timeout:   clientOptions.timeout,
+				Transport: clientOptions.transport,
 			},
 			baseURL: parsedURL,
 		},

--- a/pkg/rest/client/apiv1_client.go
+++ b/pkg/rest/client/apiv1_client.go
@@ -18,13 +18,15 @@ type Client struct {
 // "http://localhost:9000"
 func New(baseURL string, optionFuncs ...func(*ClientOptions)) (*Client, error) {
 	parsedURL, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, err
+	}
+
 	clientOptions := getDefaultClientOptions()
 	for _, optionFunc := range optionFuncs {
 		optionFunc(clientOptions)
 	}
-	if err != nil {
-		return nil, err
-	}
+
 	c := &Client{
 		restClient{
 			client: &http.Client{

--- a/pkg/rest/client/apiv1_client.go
+++ b/pkg/rest/client/apiv1_client.go
@@ -4,9 +4,10 @@ package client
 import (
 	"bytes"
 	"fmt"
-	"github.com/inbucket/inbucket/v3/pkg/rest/model"
 	"net/http"
 	"net/url"
+
+	"github.com/inbucket/inbucket/v3/pkg/rest/model"
 )
 
 // Client accesses the Inbucket REST API v1
@@ -16,15 +17,15 @@ type Client struct {
 
 // New creates a new v1 REST API client given the base URL of an Inbucket server, ex:
 // "http://localhost:9000"
-func New(baseURL string, optionFuncs ...func(*ClientOptions)) (*Client, error) {
+func New(baseURL string, opts ...ClientOption) (*Client, error) {
 	parsedURL, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, err
 	}
 
 	clientOptions := getDefaultClientOptions()
-	for _, optionFunc := range optionFuncs {
-		optionFunc(clientOptions)
+	for _, opt := range opts {
+		opt.apply(clientOptions)
 	}
 
 	c := &Client{

--- a/pkg/rest/client/apiv1_client_opts.go
+++ b/pkg/rest/client/apiv1_client_opts.go
@@ -7,7 +7,7 @@ import (
 
 // ClientOptions is a struct that holds the options for the client
 type ClientOptions struct {
-	transport *http.Transport
+	transport http.RoundTripper
 	timeout   time.Duration
 }
 
@@ -19,7 +19,7 @@ func getDefaultClientOptions() *ClientOptions {
 }
 
 // WithTransport returns a function that sets the transport object
-func WithClientOptsTransport(transport *http.Transport) func(*ClientOptions) {
+func WithClientOptsTransport(transport http.RoundTripper) func(*ClientOptions) {
 	return func(options *ClientOptions) {
 		options.transport = transport
 	}

--- a/pkg/rest/client/apiv1_client_opts.go
+++ b/pkg/rest/client/apiv1_client_opts.go
@@ -5,19 +5,18 @@ import (
 	"time"
 )
 
-// ClientOptions is a struct that holds the options for the client
-type clientOptions struct {
+// options is a struct that holds the options for the rest client
+type options struct {
 	transport http.RoundTripper
 	timeout   time.Duration
 }
 
-type ClientOption interface {
-	apply(*clientOptions)
+type Option interface {
+	apply(*options)
 }
 
-// getDefaultClientOptions returns the default options for the client
-func getDefaultClientOptions() *clientOptions {
-	return &clientOptions{
+func getDefaultOptions() *options {
+	return &options{
 		timeout: 30 * time.Second,
 	}
 }
@@ -26,11 +25,14 @@ type transportOption struct {
 	transport http.RoundTripper
 }
 
-func (t transportOption) apply(opts *clientOptions) {
+func (t transportOption) apply(opts *options) {
 	opts.transport = t.transport
 }
 
-// WithTransport returns a function that sets the transport object
-func WithClientOptsTransport(transport http.RoundTripper) ClientOption {
+// WithOptTransport sets the transport for the rest client.
+// Transport specifies the mechanism by which individual
+// HTTP requests are made.
+// If nil, http.DefaultTransport is used.
+func WithOptTransport(transport http.RoundTripper) Option {
 	return transportOption{transport}
 }

--- a/pkg/rest/client/apiv1_client_opts.go
+++ b/pkg/rest/client/apiv1_client_opts.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"net/http"
+	"time"
+)
+
+// ClientOptions is a struct that holds the options for the client
+type ClientOptions struct {
+	transport *http.Transport
+	timeout   time.Duration
+}
+
+// getDefaultClientOptions returns the default options for the client
+func getDefaultClientOptions() *ClientOptions {
+	return &ClientOptions{
+		timeout: 30 * time.Second,
+	}
+}
+
+// WithTransport returns a function that sets the transport object
+func WithTransport(transport *http.Transport) func(*ClientOptions) {
+	return func(options *ClientOptions) {
+		options.transport = transport
+	}
+}

--- a/pkg/rest/client/apiv1_client_opts.go
+++ b/pkg/rest/client/apiv1_client_opts.go
@@ -6,21 +6,31 @@ import (
 )
 
 // ClientOptions is a struct that holds the options for the client
-type ClientOptions struct {
+type clientOptions struct {
 	transport http.RoundTripper
 	timeout   time.Duration
 }
 
+type ClientOption interface {
+	apply(*clientOptions)
+}
+
 // getDefaultClientOptions returns the default options for the client
-func getDefaultClientOptions() *ClientOptions {
-	return &ClientOptions{
+func getDefaultClientOptions() *clientOptions {
+	return &clientOptions{
 		timeout: 30 * time.Second,
 	}
 }
 
+type transportOption struct {
+	transport http.RoundTripper
+}
+
+func (t transportOption) apply(opts *clientOptions) {
+	opts.transport = t.transport
+}
+
 // WithTransport returns a function that sets the transport object
-func WithClientOptsTransport(transport http.RoundTripper) func(*ClientOptions) {
-	return func(options *ClientOptions) {
-		options.transport = transport
-	}
+func WithClientOptsTransport(transport http.RoundTripper) ClientOption {
+	return transportOption{transport}
 }

--- a/pkg/rest/client/apiv1_client_opts.go
+++ b/pkg/rest/client/apiv1_client_opts.go
@@ -19,7 +19,7 @@ func getDefaultClientOptions() *ClientOptions {
 }
 
 // WithTransport returns a function that sets the transport object
-func WithTransport(transport *http.Transport) func(*ClientOptions) {
+func WithClientOptsTransport(transport *http.Transport) func(*ClientOptions) {
 	return func(options *ClientOptions) {
 		options.transport = transport
 	}

--- a/pkg/rest/client/apiv1_client_test.go
+++ b/pkg/rest/client/apiv1_client_test.go
@@ -2,7 +2,7 @@ package client_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -375,7 +375,7 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	m.CallCount++
 	return &http.Response{
 		StatusCode: http.StatusOK,
-		Body:       ioutil.NopCloser(bytes.NewBufferString(m.ResponseBody)),
+		Body:       io.NopCloser(bytes.NewBufferString(m.ResponseBody)),
 	}, nil
 }
 

--- a/pkg/rest/client/apiv1_client_test.go
+++ b/pkg/rest/client/apiv1_client_test.go
@@ -215,7 +215,7 @@ func TestClientV1GetMessageSource(t *testing.T) {
 func TestClientV1WithCustomTransport(t *testing.T) {
 	// Call setup, passing a custom roundtripper and make sure it was used during the request.
 	mockRoundTripper := &mockRoundTripper{ResponseBody: "Custom Transport"}
-	c, router, teardown := setup(client.WithClientOptsTransport(mockRoundTripper))
+	c, router, teardown := setup(client.WithOptTransport(mockRoundTripper))
 
 	defer teardown()
 
@@ -380,7 +380,7 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 }
 
 // setup returns a client, router and server for API testing.
-func setup(opts ...client.ClientOption) (c *client.Client, router *mux.Router, teardown func()) {
+func setup(opts ...client.Option) (c *client.Client, router *mux.Router, teardown func()) {
 	router = mux.NewRouter()
 	server := httptest.NewServer(router)
 	c, err := client.New(server.URL, opts...)

--- a/pkg/rest/client/apiv1_client_test.go
+++ b/pkg/rest/client/apiv1_client_test.go
@@ -1,6 +1,8 @@
 package client_test
 
 import (
+	"bytes"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -210,6 +212,33 @@ func TestClientV1GetMessageSource(t *testing.T) {
 	}
 }
 
+func TestClientV1WithCustomTransport(t *testing.T) {
+	// Call setup, passing a custom roundtripper and make sure it was used during the request.
+	mockRoundTripper := &mockRoundTripper{ResponseBody: "Custom Transport"}
+	c, router, teardown := setup(client.WithClientOptsTransport(mockRoundTripper))
+
+	defer teardown()
+
+	router.Path("/api/v1/mailbox/testbox/20170107T224128-0000/source").Methods("GET").
+		Handler(&jsonHandler{json: `message source`})
+
+	// Method under test.
+	source, err := c.GetMessageSource("testbox", "20170107T224128-0000")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := mockRoundTripper.ResponseBody
+	got := source.String()
+	if got != want {
+		t.Errorf("Source got %q, want %q", got, want)
+	}
+
+	if mockRoundTripper.CallCount != 1 {
+		t.Errorf("RoundTripper called %v times, want 1", mockRoundTripper.CallCount)
+	}
+}
+
 func TestClientV1DeleteMessage(t *testing.T) {
 	// Setup.
 	c, router, teardown := setup()
@@ -337,11 +366,24 @@ func TestClientV1MessageHeader(t *testing.T) {
 	}
 }
 
+type mockRoundTripper struct {
+	ResponseBody string
+	CallCount    int
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.CallCount++
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(m.ResponseBody)),
+	}, nil
+}
+
 // setup returns a client, router and server for API testing.
-func setup() (c *client.Client, router *mux.Router, teardown func()) {
+func setup(opts ...client.ClientOption) (c *client.Client, router *mux.Router, teardown func()) {
 	router = mux.NewRouter()
 	server := httptest.NewServer(router)
-	c, err := client.New(server.URL)
+	c, err := client.New(server.URL, opts...)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The rest client does not currently allow a user to pass options, such as a custom transport. This PR extends the `client.New` function to allow for custom options to be passed