### PR TITLE
fix: prevent smtp/handler test from freezing on panic

### DIFF
--- a/pkg/server/smtp/handler.go
+++ b/pkg/server/smtp/handler.go
@@ -139,20 +139,23 @@ func (s *Session) String() string {
 	return fmt.Sprintf("Session{id: %v, state: %v}", s.id, s.state)
 }
 
-/* Session flow:
- *  1. Send initial greeting
- *  2. Receive cmd
- *  3. If good cmd, respond, optionally change state
- *  4. If bad cmd, respond error
- *  5. Goto 2
- */
+// Session flow:
+//  1. Send initial greeting
+//  2. Receive cmd
+//  3. If good cmd, respond, optionally change state
+//  4. If bad cmd, respond error
+//  5. Goto 2
 func (s *Server) startSession(id int, conn net.Conn, logger zerolog.Logger) {
 	logger = logger.Hook(logHook{}).With().
 		Str("module", "smtp").
 		Str("remote", conn.RemoteAddr().String()).
 		Int("session", id).Logger()
 	logger.Info().Msg("Starting SMTP session")
+
+	// Update WaitGroup and counters.
+	s.wg.Add(1)
 	expConnectsCurrent.Add(1)
+	expConnectsTotal.Add(1)
 	defer func() {
 		if err := conn.Close(); err != nil {
 			logger.Warn().Err(err).Msg("Closing connection")

--- a/pkg/server/smtp/handler_test.go
+++ b/pkg/server/smtp/handler_test.go
@@ -558,7 +558,6 @@ func setupSMTPSession(t *testing.T, server *Server) net.Conn {
 	serverConn, clientConn := net.Pipe()
 
 	// Start the session.
-	server.wg.Add(1)
 	sessionNum++
 	go server.startSession(sessionNum, &mockConn{serverConn}, logger)
 

--- a/pkg/server/smtp/listener.go
+++ b/pkg/server/smtp/listener.go
@@ -176,8 +176,6 @@ func (s *Server) serve(ctx context.Context) {
 			}
 		} else {
 			tempDelay = 0
-			expConnectsTotal.Add(1)
-			s.wg.Add(1)
 			go s.startSession(sessionID, conn, log.Logger)
 		}
 	}


### PR DESCRIPTION
- chore: colocate SMTP session WaitGroup incr/decr
- fix: smtp tests that hang on panic/t.Fatal
- chore: reorder smtp/handler test helpers
