### PR TITLE
fix: skip-pkg-cache no longer supported by golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,3 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
-          # Disable cache to prevent `File exists` errors.
-          # https://github.com/golangci/golangci-lint-action/issues/135
-          skip-pkg-cache: true


### PR DESCRIPTION
Signed-off-by: James Hillyerd <james@hillyerd.com>
