### PR TITLE
chore: disable deprecated execinquery linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,6 @@ linters:
     - errchkjson
     - errname
     # - errorlint
-    - execinquery
     # - exhaustive
     - exportloopref
     # - forcetypeassert


### PR DESCRIPTION
Signed-off-by: James Hillyerd <james@hillyerd.com>
