### PR TITLE
Accept and handle emails sent with an empty 821.From / return-path

### DIFF
--- a/pkg/message/manager.go
+++ b/pkg/message/manager.go
@@ -112,7 +112,7 @@ func (s *StoreManager) Deliver(
 	for _, mb := range inbound.Mailboxes {
 		// Append recipient and timestamp to generated Received header.
 		recvd := fmt.Sprintf("%s  for <%s>; %s\r\n", recvdHeader, mb, tstamp)
-
+		returnPath := fmt.Sprintf("Return-Path: <%s>\r\n", from.Address.Address)
 		// Deliver message.
 		logger.Debug().Str("mailbox", mb).Msg("Delivering message")
 		delivery := &Delivery{
@@ -124,7 +124,7 @@ func (s *StoreManager) Deliver(
 				Subject: inbound.Subject,
 				Size:    inbound.Size,
 			},
-			Reader: io.MultiReader(strings.NewReader(recvd), bytes.NewReader(source)),
+			Reader: io.MultiReader(strings.NewReader(returnPath), strings.NewReader(recvd), bytes.NewReader(source)),
 		}
 		id, err := s.Store.AddMessage(delivery)
 		if err != nil {

--- a/pkg/policy/address.go
+++ b/pkg/policy/address.go
@@ -75,6 +75,11 @@ func (a *Addressing) NewRecipient(address string) (*Recipient, error) {
 // ParseOrigin parses an address into a Origin. This is used for parsing MAIL FROM argument,
 // not To headers.
 func (a *Addressing) ParseOrigin(address string) (*Origin, error) {
+	if address == "" {
+		return &Origin{
+			addrPolicy: a,
+		}, nil
+	}
 	local, domain, err := ParseEmailAddress(address)
 	if err != nil {
 		return nil, err

--- a/pkg/server/smtp/handler.go
+++ b/pkg/server/smtp/handler.go
@@ -411,18 +411,6 @@ func (s *Session) parseMailFromCmd(arg string) {
 	from := m[1]
 	s.logger.Debug().Msgf("Mail sender is %v", from)
 
-	// Parse from address.
-	_, domain, err := policy.ParseEmailAddress(from)
-	s.logger.Debug().Msgf("Origin domain is %v", domain)
-	if from != "" && err != nil {
-		s.send("501 Bad sender address syntax")
-		s.logger.Warn().Msgf("Bad address as MAIL arg: %q, %s", from, err)
-		return
-	}
-	if from == "" {
-		from = "unspecified"
-	}
-
 	// Parse ESMTP parameters.
 	if m[2] != "" {
 		// Here the client may put BODY=8BITMIME, but Inbucket already
@@ -480,7 +468,7 @@ func (s *Session) parseMailFromCmd(arg string) {
 	// Ignore ShouldAccept if extensions explicitly allowed this From.
 	if extAction == event.ActionDefer && !s.from.ShouldAccept() {
 		s.send("501 Unauthorized domain")
-		s.logger.Warn().Msgf("Bad domain sender %s", domain)
+		s.logger.Warn().Msgf("Bad domain sender %s", origin.Domain)
 		return
 	}
 

--- a/pkg/server/smtp/handler_test.go
+++ b/pkg/server/smtp/handler_test.go
@@ -85,14 +85,14 @@ func TestEmptyEnvelope(t *testing.T) {
 	// Test out some empty envelope without blanks
 	script := []scriptStep{
 		{"HELO localhost", 250},
-		{"MAIL FROM:<>", 501},
+		{"MAIL FROM:<>", 250},
 	}
 	playSession(t, server, script)
 
 	// Test out some empty envelope with blanks
 	script = []scriptStep{
 		{"HELO localhost", 250},
-		{"MAIL FROM: <>", 501},
+		{"MAIL FROM: <>", 250},
 	}
 	playSession(t, server, script)
 }


### PR DESCRIPTION
Passes unit tests.

Manual testing via the web UI after delivering mails with an empty 821.From, both with and without a 5322 From: header shows no problems.

Inbucket's use of the 821.From is a little odd. It's not stored with the message explicitly, and is almost always discarded. It is used only if there's no email address in the 5322.From: - in that case it is used as if it were in the 5322.From: header. Because of that I doubt that supporting an empty 821.From will have any effect on other functionality.

Closes #558.