### PR TITLE
Add the 821.From / return-path of an email to the stored message

### DIFF
--- a/pkg/message/manager.go
+++ b/pkg/message/manager.go
@@ -112,7 +112,7 @@ func (s *StoreManager) Deliver(
 	for _, mb := range inbound.Mailboxes {
 		// Append recipient and timestamp to generated Received header.
 		recvd := fmt.Sprintf("%s  for <%s>; %s\r\n", recvdHeader, mb, tstamp)
-
+		returnPath := fmt.Sprintf("Return-Path: <%s>\r\n", from.Address.Address)
 		// Deliver message.
 		logger.Debug().Str("mailbox", mb).Msg("Delivering message")
 		delivery := &Delivery{
@@ -124,7 +124,7 @@ func (s *StoreManager) Deliver(
 				Subject: inbound.Subject,
 				Size:    inbound.Size,
 			},
-			Reader: io.MultiReader(strings.NewReader(recvd), bytes.NewReader(source)),
+			Reader: io.MultiReader(strings.NewReader(returnPath), strings.NewReader(recvd), bytes.NewReader(source)),
 		}
 		id, err := s.Store.AddMessage(delivery)
 		if err != nil {

--- a/pkg/test/testdata/basic.golden
+++ b/pkg/test/testdata/basic.golden
@@ -2,7 +2,7 @@ Mailbox: recipient
 From: <fromuser@inbucket.org>
 To: [<recipient@inbucket.org>]
 Subject: basic subject
-Size: 204
+Size: 242
 
 BODY TEXT:
 Basic message.

--- a/pkg/test/testdata/encodedheader.golden
+++ b/pkg/test/testdata/encodedheader.golden
@@ -2,7 +2,7 @@ Mailbox: recipient
 From: X-äéß Y-äéß <fromuser@inbucket.org>
 To: [Test of ȇɲʢȯȡɪɴʛ <recipient@inbucket.org>]
 Subject: Test of ȇɲʢȯȡɪɴʛ
-Size: 338
+Size: 376
 
 BODY TEXT:
 Basic message.

--- a/pkg/test/testdata/fullname.golden
+++ b/pkg/test/testdata/fullname.golden
@@ -2,7 +2,7 @@ Mailbox: recipient
 From: From User <fromuser@inbucket.org>
 To: [Rec I. Pient <recipient@inbucket.org>]
 Subject: basic subject
-Size: 233
+Size: 271
 
 BODY TEXT:
 Basic message.

--- a/pkg/test/testdata/no-to-ipv4.golden
+++ b/pkg/test/testdata/no-to-ipv4.golden
@@ -2,7 +2,7 @@ Mailbox: ip4recipient
 From: <fromuser@inbucket.org>
 To: [<ip4recipient@[192.168.123.123]>]
 Subject: basic subject
-Size: 180
+Size: 218
 
 BODY TEXT:
 No-To message.

--- a/pkg/test/testdata/no-to-ipv6.golden
+++ b/pkg/test/testdata/no-to-ipv6.golden
@@ -2,7 +2,7 @@ Mailbox: ip6recipient
 From: <fromuser@inbucket.org>
 To: [<ip6recipient@[IPv6:2001:0db8:85a3:0000:0000:8a2e:0370:7334]>]
 Subject: basic subject
-Size: 180
+Size: 218
 
 BODY TEXT:
 No-To message.


### PR DESCRIPTION
Add the 821.From / return-path of an email to the stored message as a Return-Path: header. This is visible in the source view and as a header via the REST API.

Passes tests, UI appears to work correctly.