### PR TITLE
Accept and handle emails sent with an empty 821.From / return-path as…

### DIFF
--- a/pkg/policy/address.go
+++ b/pkg/policy/address.go
@@ -75,6 +75,11 @@ func (a *Addressing) NewRecipient(address string) (*Recipient, error) {
 // ParseOrigin parses an address into a Origin. This is used for parsing MAIL FROM argument,
 // not To headers.
 func (a *Addressing) ParseOrigin(address string) (*Origin, error) {
+	if address == "" {
+		return &Origin{
+			addrPolicy: a,
+		}, nil
+	}
 	local, domain, err := ParseEmailAddress(address)
 	if err != nil {
 		return nil, err

--- a/pkg/server/smtp/handler.go
+++ b/pkg/server/smtp/handler.go
@@ -411,18 +411,6 @@ func (s *Session) parseMailFromCmd(arg string) {
 	from := m[1]
 	s.logger.Debug().Msgf("Mail sender is %v", from)
 
-	// Parse from address.
-	_, domain, err := policy.ParseEmailAddress(from)
-	s.logger.Debug().Msgf("Origin domain is %v", domain)
-	if from != "" && err != nil {
-		s.send("501 Bad sender address syntax")
-		s.logger.Warn().Msgf("Bad address as MAIL arg: %q, %s", from, err)
-		return
-	}
-	if from == "" {
-		from = "unspecified"
-	}
-
 	// Parse ESMTP parameters.
 	if m[2] != "" {
 		// Here the client may put BODY=8BITMIME, but Inbucket already
@@ -480,7 +468,7 @@ func (s *Session) parseMailFromCmd(arg string) {
 	// Ignore ShouldAccept if extensions explicitly allowed this From.
 	if extAction == event.ActionDefer && !s.from.ShouldAccept() {
 		s.send("501 Unauthorized domain")
-		s.logger.Warn().Msgf("Bad domain sender %s", domain)
+		s.logger.Warn().Msgf("Bad domain sender %s", origin.Domain)
 		return
 	}
 

--- a/pkg/server/smtp/handler_test.go
+++ b/pkg/server/smtp/handler_test.go
@@ -85,14 +85,14 @@ func TestEmptyEnvelope(t *testing.T) {
 	// Test out some empty envelope without blanks
 	script := []scriptStep{
 		{"HELO localhost", 250},
-		{"MAIL FROM:<>", 501},
+		{"MAIL FROM:<>", 250},
 	}
 	playSession(t, server, script)
 
 	// Test out some empty envelope with blanks
 	script = []scriptStep{
 		{"HELO localhost", 250},
-		{"MAIL FROM: <>", 501},
+		{"MAIL FROM: <>", 250},
 	}
 	playSession(t, server, script)
 }


### PR DESCRIPTION
Accept and handle emails sent with an empty 821.From / return-path as it would any other email.

Passes unit tests.

Manual testing via the web UI after delivering mails with an empty 821.From, both with and without a 5322 From: header shows no problems.

Inbucket doesn't display the 821.From in the UI, so previous concerns about an empty field breaking the UI aren't an issue, so the previous code that replaced an empty 821.From with the string "unassigned" have been removed (and they've not had any effect for years)

Closes https://github.com/inbucket/inbucket/issues/558.