### PR TITLE
Add AllowDomains validation for SMTP sender domains

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,6 +82,7 @@ type SMTP struct {
 	AcceptDomains       []string      `desc:"Domains to accept mail for"`
 	RejectDomains       []string      `desc:"Domains to reject mail for"`
 	DefaultStore        bool          `required:"true" default:"true" desc:"Store all mail by default?"`
+	AllowDomains 		[]string 	  `desc:"Domains to allow mail for"`
 	StoreDomains        []string      `desc:"Domains to store mail for"`
 	DiscardDomains      []string      `desc:"Domains to discard mail for"`
 	RejectOriginDomains []string      `desc:"Domains to reject mail from"`
@@ -133,6 +134,7 @@ func Process() (*Root, error) {
 	stringutil.SliceToLower(c.SMTP.AcceptDomains)
 	stringutil.SliceToLower(c.SMTP.RejectDomains)
 	stringutil.SliceToLower(c.SMTP.StoreDomains)
+	stringutil.SliceToLower(c.SMTP.AllowDomains)
 	stringutil.SliceToLower(c.SMTP.DiscardDomains)
 	stringutil.SliceToLower(c.SMTP.RejectOriginDomains)
 	return c, err

--- a/pkg/policy/address.go
+++ b/pkg/policy/address.go
@@ -123,6 +123,17 @@ func (a *Addressing) ShouldStoreDomain(domain string) bool {
 // ShouldAcceptOriginDomain indicates if Inbucket accept mail from the specified domain.
 func (a *Addressing) ShouldAcceptOriginDomain(domain string) bool {
 	domain = strings.ToLower(domain)
+
+	// If AllowDomains is configured, only these domains are accepted.
+	if len(a.Config.SMTP.AllowDomains) > 0 {
+		for _, d := range a.Config.SMTP.AllowDomains {
+			if stringutil.MatchWithWildcards(d, domain) {
+				return true
+			}
+		}
+		return false
+	}
+	
 	if len(a.Config.SMTP.RejectOriginDomains) > 0 {
 		for _, d := range a.Config.SMTP.RejectOriginDomains {
 			if stringutil.MatchWithWildcards(d, domain) {

--- a/pkg/policy/address_test.go
+++ b/pkg/policy/address_test.go
@@ -513,3 +513,74 @@ func TestRecipientAddress(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldAcceptOriginDomain(t *testing.T) {
+	// Test AllowDomains feature.
+	ap := &policy.Addressing{
+		Config: &config.Root{
+			SMTP: config.SMTP{
+				AllowDomains: []string{"cyblance.com"},
+			},
+		},
+	}
+
+	testCases := []struct {
+		domain string
+		want   bool
+	}{
+
+		{domain: "cyblance.com", want: true},
+		{domain: "CYBLANCE.COM", want: true},
+		{domain: "company.com", want: false},
+		{domain: "COMPANY.COM", want: false},
+		{domain: "gmail.com", want: false},
+		{domain: "GMAIL.COM", want: false},
+		{domain: "hotmail.com", want: false},
+		{domain: "HOTMAIL.COM", want: false}, 
+		{domain: "yahoo.com", want: false},
+		{domain: "YAHOO.COM", want: false},
+		{domain: "example.com", want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.domain, func(t *testing.T) {
+			got := ap.ShouldAcceptOriginDomain(tc.domain)
+			if got != tc.want {
+				t.Errorf("Got %v for %q, want %v", got, tc.domain, tc.want)
+			}
+		})
+	}
+
+	// Test RejectOriginDomains still works when AllowDomains is empty.
+	ap = &policy.Addressing{
+		Config: &config.Root{
+			SMTP: config.SMTP{
+				RejectOriginDomains: []string{"spam.com"},
+			},
+		},
+	}
+
+	testCases = []struct {
+		domain string
+		want   bool
+	}{
+		{domain: "cyblance.com", want: true},
+		{domain: "CYBLANCE.COM", want: true},
+		{domain: "company.com", want: true},
+		{domain: "COMPANY.COM", want: true},
+		{domain: "spam.com", want: false},
+		{domain: "SPAM.COM", want: false},
+		{domain: "gmail.com", want: true},
+		{domain: "hotmail.com", want: true},
+		{domain: "yahoo.com", want: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run("reject_"+tc.domain, func(t *testing.T) {
+			got := ap.ShouldAcceptOriginDomain(tc.domain)
+			if got != tc.want {
+				t.Errorf("Got %v for %q, want %v", got, tc.domain, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for validating sender domains using the existing AllowDomains configuration.

Behavior:
- Empty AllowDomains allows all domains.
- If AllowDomains is configured, only matching sender domains are accepted.
- Non-matching domains return an SMTP rejection.

Includes unit tests.