### PR TITLE
fix(nix): use top-level node-gyp/yarn and nodejs_22 in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -28,9 +28,9 @@ pkgs.mkShell {
     golangci-lint
     golint
     gopls
-    nodejs_20
-    nodePackages.node-gyp
-    nodePackages.yarn
+    nodejs_22
+    node-gyp
+    yarn
     rpm
     swaks
 


### PR DESCRIPTION
nodePackages was removed from nixpkgs; node-gyp and yarn are now
top-level packages. Also switch nodejs_20 to nodejs_22, as
nodejs-20.20.2 is now marked insecure and fails to build without
permittedInsecurePackages.
