### PR TITLE
fix: swaks file syntax in tests, log header parse failures

### DIFF
--- a/etc/swaks-tests/run-tests.sh
+++ b/etc/swaks-tests/run-tests.sh
@@ -28,41 +28,41 @@ export SWAKS_OPT_server="${SWAKS_OPT_server:-127.0.0.1:2500}"
 export SWAKS_OPT_to="$to@inbucket.local"
 
 # Basic test
-swaks $* --h-Subject: "Swaks Plain Text" --body text.txt
+swaks $* --h-Subject: "Swaks Plain Text" --body @text.txt
 
 # Multi-recipient test
 swaks $* --to="$to@inbucket.local,alternate@inbucket.local" --h-Subject: "Swaks Multi-Recipient" \
-  --body text.txt
+  --body @text.txt
 
 # HTML test
-swaks $* --h-Subject: "Swaks HTML" --data mime-html.raw
+swaks $* --h-Subject: "Swaks HTML" --data @mime-html.raw
 
 # Top level HTML test
-swaks $* --h-Subject: "Swaks Top Level HTML" --data nonmime-html.raw
+swaks $* --h-Subject: "Swaks Top Level HTML" --data @nonmime-html.raw
 
 # Attachment test
 swaks $* --h-Subject: "Swaks Attachment" --attach-type image/png --attach favicon.png \
-  --body text.txt
+  --body @text.txt
 
 # Encoded subject line test
-swaks $* --data utf8-subject.raw
+swaks $* --data @utf8-subject.raw
 
 # Gmail test
-swaks $* --data gmail.raw
+swaks $* --data @gmail.raw
 
 # Outlook test
-swaks $* --data outlook.raw
+swaks $* --data @outlook.raw
 
 # Non-mime responsive HTML test
-swaks $* --data nonmime-html-responsive.raw
-swaks $* --data nonmime-html-inlined.raw
+swaks $* --data @nonmime-html-responsive.raw
+swaks $* --data @nonmime-html-inlined.raw
 
 # Incorrect charset, malformed final boundary
-swaks $* --data mime-errors.raw
+swaks $* --data @mime-errors.raw
 
 # IP RCPT domain
-swaks $* --to="swaks@[127.0.0.1]" --h-Subject: "IPv4 RCPT Address" --body text.txt
-swaks $* --to="swaks@[IPv6:2001:db8:aaaa:1::100]" --h-Subject: "IPv6 RCPT Address" --body text.txt
+swaks $* --to="swaks@[127.0.0.1]" --h-Subject: "IPv4 RCPT Address" --body @text.txt
+swaks $* --to="swaks@[IPv6:2001:db8:aaaa:1::100]" --h-Subject: "IPv6 RCPT Address" --body @text.txt
 
 # Inline attachment test
-swaks $* --data mime-inline.raw
+swaks $* --data @mime-inline.raw

--- a/pkg/message/manager.go
+++ b/pkg/message/manager.go
@@ -55,6 +55,7 @@ func (s *StoreManager) Deliver(
 	// Parse envelope headers.
 	header, err := enmime.DecodeHeaders(source)
 	if err != nil {
+		logger.Error().Err(err).Msg("Failed to parse message headers")
 		return err
 	}
 


### PR DESCRIPTION
## Problem

Running `./etc/swaks-tests/run-tests.sh` against a local inbucket failed on the HTML test with SMTP `451 Failed to store message`, and **no error appeared in the inbucket log**.

Two separate issues:

### 1. Outdated swaks file syntax in run-tests.sh

Modern swaks (20240103.0) only reads an option value from a file when it is prefixed with `@`. `swaks --data mime-html.raw` now sends the *literal filename* as the message body, so the server tried to parse `"mime-html.raw"` as a MIME header and rejected the message:

```
malformed MIME header: missing colon: "mime-html.raw"
```

Fixed by using `--data @file.raw` (and `--body @text.txt`) throughout the script.

### 2. Silent delivery failure

`smtp.Session.dataHandler` returns `451 Failed to store message` without logging, relying on `StoreManager.Deliver` to log failure details. However `Deliver()` only logged `Store.AddMessage` errors; the header parse error from `enmime.DecodeHeaders` was returned without any log output. Add a single error log so parse failures are visible server-side.

## Testing

- Full `run-tests.sh` suite passes (exit 0, 14 deliveries, no 451 responses, clean server log)
- `go test -race ./pkg/message/... ./pkg/server/smtp/...` passes